### PR TITLE
assertions on logs through python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
+language: python
 sudo: required
+python: '2.7'
+cache: pip
 
 services:
   - docker
@@ -11,11 +14,19 @@ before_install:
   - sleep 80
   - docker ps -a
   - docker exec -ti db nodetool status
+  - docker exec -ti smsc bash -c 'ps -ef | grep jboss'
 
 script:
 #  - echo "The following test is pending: https://github.com/RestComm/smscgateway/blob/master/core/domain/src/test/java/org/mobicents/smsc/domain/SmscDatabaseManagementTest.java#L40"
+  - pip install -r requirements.txt
+  - python test.py
+  - printf "\n\nserver.log\n\n"
+  - docker cp smsc:/opt/Restcomm-SMSC/jboss-5.1.0.GA/server/simulator/log/server.log server.log
+  - cat server.log
+  - printf "\n\nboot.log\n\n"
+  - docker cp smsc:/opt/Restcomm-SMSC/jboss-5.1.0.GA/server/simulator/log/boot.log boot.log
+  - cat boot.log
+  - printf "\n\ncdr.log\n\n"
+  - docker cp smsc:/opt/Restcomm-SMSC/jboss-5.1.0.GA/server/simulator/log/cdr.log cdr.log
+  - cat cdr.log
 
-# valid call to get list of sms messages with wrong credentials (non existent account)
-  - docker exec -ti smsc curl -X GET http://ACae6e420f425248d6a26948c17a9e2acf:77f8c12cc7b8f8423e5c38b035249166@127.0.0.1:8080/restcomm/2012-04-24/Accounts/ACae6e420f425248d6a26948c17a9e2acf/SMS/Messages.json
-  - sudo bash provisioner/docker_do.sh -c smsc -l
-  - sudo bash provisioner/logs.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,27 @@ services:
   - docker
 
 before_install: 
-  - pip install -r requirements.txt
   - docker run --name db --net=host -p 127.0.0.1:9042:9042 -p 127.0.0.1:9160:9160 -d cassandra
+
+install:
+  - echo 'travis is now testing that the docker can be built'
   - docker build -t image .
-  - docker run --name smsc --net=host -e ENVCONFURL="https://raw.githubusercontent.com/RestComm/smscgateway-docker/master/env_files/restcomm_env_smsc_locally.sh" -p 0.0.0.0:8080:8080 -d image
+  - echo 'built successfully'
+  - echo 'travis is now testing that the docker can run'
+  - docker run --name smsc --net=host -e ENVCONFURL="https://raw.githubusercontent.com/RestComm/smscgateway-docker/master/env_files/restcomm_env_smsc_locally.sh" -p 0.0.0.0:8080:8080 -p 0.0.0.0:3435:3435 -d image
   - echo 'waiting 80 seconds for jboss to start...'
   - sleep 80
   - docker ps -a
   - docker exec -ti db nodetool status
   - docker exec -ti smsc bash -c 'ps -ef | grep jboss'
+
+script:
+  - pip install -r requirements.txt
   - docker cp smsc:/opt/Restcomm-SMSC/jboss-5.1.0.GA/server/simulator/log/server.log server.log
   - docker cp smsc:/opt/Restcomm-SMSC/jboss-5.1.0.GA/server/simulator/log/boot.log boot.log
   - docker cp smsc:/opt/Restcomm-SMSC/jboss-5.1.0.GA/server/simulator/log/cdr.log cdr.log
-
-script:
-#  - echo "The following test is pending: https://github.com/RestComm/smscgateway/blob/master/core/domain/src/test/java/org/mobicents/smsc/domain/SmscDatabaseManagementTest.java#L40"
   - python test.py
+  - echo 'run successfully'
+
+after_success:
+  - docker exec -ti smsc bash /opt/Restcomm-SMSC/jboss-5.1.0.GA/bin/ss7-cli.sh -h

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
   - docker
 
 before_install: 
+  - pip install -r requirements.txt
   - docker run --name db --net=host -p 127.0.0.1:9042:9042 -p 127.0.0.1:9160:9160 -d cassandra
   - docker build -t image .
   - docker run --name smsc --net=host -e ENVCONFURL="https://raw.githubusercontent.com/RestComm/smscgateway-docker/master/env_files/restcomm_env_smsc_locally.sh" -p 0.0.0.0:8080:8080 -d image
@@ -15,18 +16,10 @@ before_install:
   - docker ps -a
   - docker exec -ti db nodetool status
   - docker exec -ti smsc bash -c 'ps -ef | grep jboss'
+  - docker cp smsc:/opt/Restcomm-SMSC/jboss-5.1.0.GA/server/simulator/log/server.log server.log
+  - docker cp smsc:/opt/Restcomm-SMSC/jboss-5.1.0.GA/server/simulator/log/boot.log boot.log
+  - docker cp smsc:/opt/Restcomm-SMSC/jboss-5.1.0.GA/server/simulator/log/cdr.log cdr.log
 
 script:
 #  - echo "The following test is pending: https://github.com/RestComm/smscgateway/blob/master/core/domain/src/test/java/org/mobicents/smsc/domain/SmscDatabaseManagementTest.java#L40"
-  - pip install -r requirements.txt
   - python test.py
-  - printf "\n\nserver.log\n\n"
-  - docker cp smsc:/opt/Restcomm-SMSC/jboss-5.1.0.GA/server/simulator/log/server.log server.log
-  - cat server.log
-  - printf "\n\nboot.log\n\n"
-  - docker cp smsc:/opt/Restcomm-SMSC/jboss-5.1.0.GA/server/simulator/log/boot.log boot.log
-  - cat boot.log
-  - printf "\n\ncdr.log\n\n"
-  - docker cp smsc:/opt/Restcomm-SMSC/jboss-5.1.0.GA/server/simulator/log/cdr.log cdr.log
-  - cat cdr.log
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,4 @@ ln -sf /dev/stdout /opt/Restcomm-SMSC/version && \
 ln -sf /dev/stdout /opt/Restcomm-SMSC/jboss-5.1.0.GA/server/default/log/server.log && \
 ln -sf /dev/stdout /opt/Restcomm-SMSC/jboss-5.1.0.GA/server/default/log/boot.log
 
-EXPOSE 8080 
+EXPOSE 8080 3435

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests[security]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ndg-httpsclient
-requests[security]
+pyasn1
+requests[security]==2.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+ndg-httpsclient
 requests[security]

--- a/test.py
+++ b/test.py
@@ -1,42 +1,39 @@
-import json
-import requests
-from requests.auth import HTTPBasicAuth
+from re import search
 
 
-class Messages(object):
-    sid = ''
-    token = ''
-    def __init__(self, sid, token):
-        self.sid = sid
-        self.token = token
-    def http(self, body_dict=None):
-        """
-        @type body_dict: dict
-        @param body_dict: {To': dest, 'From': src, 'Body': text} to send SMS or None to get the list of SMS
-        @rtype: requests.Response
-        """
-        #protocol_host_port = 'https://tadhack.restcomm.com'
-        protocol_host_port = 'http://127.0.0.1:8080'
-        auth = (self.sid, self.token)
-        urlprefix = protocol_host_port + "/restcomm/2012-04-24/Accounts/" + self.sid
-        endpoint = '/SMS/Messages.json'
-        url = urlprefix + endpoint
-        method = 'GET'
-        if body_dict!=None:
-            method = 'POST'
-            body_dict = json.dumps(body_dict)
-        response = requests.request(method, url, data=body_dict, timeout=120)
-        return response
+def line(regex, filepath):
+    """
+    Returns all lines that have the term or the empty string
+    """
+    result = ''
+    counter = 0
+    with open(filepath, 'r') as inF:
+        for line in inF:
+            counter += 1
+            match = search(regex, line)
+            if match:
+                matched = match.group()
+                if result==False:
+                    result = "line %d: %s\n" % (counter, matched)
+                else:
+                    result += "line %d: %s\n" % (counter, matched)
+    return result
+
+
+def has(regex, filepath):
+    start_msg = line(regex, filepath)
+    assert start_msg!='', "Expected a line with %s\n\n%s\n\n%s" % (regex, filepath, open(filepath).read())
+
+
+def has_not(regex, filepath):
+    failed_to_start_msg = line(regex, filepath)
+    assert failed_to_start_msg=='', "Expected the file %s to have no line with %s but found: %s\n\n%s" % (filepath, regex, failed_to_start_msg, open(filepath).read())
+
 
 def main():
-    #sid = open('sid').read().strip()
-    #token = open('token').read().strip()
-    sid = 'sid'
-    token = 'token'
-    smsc = Messages(sid, token)
-    status = smsc.http().status_code
-    assert status==401, "Expected status 401 but got %d at /SMS/Messages.json" % status
+    has("INFO.*org.jboss.bootstrap.microcontainer.ServerImpl.*JBoss.*Started", 'server.log')
+    has_not(".*Not all SBB are running now.*", 'server.log')
+
 
 if __name__=='__main__':
     main()
-

--- a/test.py
+++ b/test.py
@@ -1,0 +1,42 @@
+import json
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+class Messages(object):
+    sid = ''
+    token = ''
+    def __init__(self, sid, token):
+        self.sid = sid
+        self.token = token
+    def http(self, body_dict=None):
+        """
+        @type body_dict: dict
+        @param body_dict: {To': dest, 'From': src, 'Body': text} to send SMS or None to get the list of SMS
+        @rtype: requests.Response
+        """
+        #host = 'tadhack.restcomm.com'
+        host = '127.0.0.1'
+        auth = (self.sid, self.token)
+        urlprefix = "https://%s/restcomm/2012-04-24/Accounts/%s" % (host, self.sid)
+        endpoint = '/SMS/Messages.json'
+        url = urlprefix + endpoint
+        method = 'GET'
+        if body_dict!=None:
+            method = 'POST'
+            body_dict = json.dumps(body_dict)
+        response = requests.request(method, url, data=body_dict, timeout=120)
+        return response
+
+def main():
+    #sid = open('sid').read().strip()
+    #token = open('token').read().strip()
+    sid = 'sid'
+    token = 'token'
+    smsc = Messages(sid, token)
+    status = smsc.http().status_code
+    assert status==401, "Expected status 401 but got %d at /SMS/Messages.json" % status
+
+if __name__=='__main__':
+    main()
+

--- a/test.py
+++ b/test.py
@@ -16,7 +16,7 @@ class Messages(object):
         @rtype: requests.Response
         """
         #host = 'tadhack.restcomm.com'
-        host = '127.0.0.1'
+        host = '127.0.0.1:8080'
         auth = (self.sid, self.token)
         urlprefix = "https://%s/restcomm/2012-04-24/Accounts/%s" % (host, self.sid)
         endpoint = '/SMS/Messages.json'

--- a/test.py
+++ b/test.py
@@ -15,10 +15,10 @@ class Messages(object):
         @param body_dict: {To': dest, 'From': src, 'Body': text} to send SMS or None to get the list of SMS
         @rtype: requests.Response
         """
-        #host = 'tadhack.restcomm.com'
-        host = '127.0.0.1:8080'
+        #protocol_host_port = 'https://tadhack.restcomm.com'
+        protocol_host_port = 'http://127.0.0.1:8080'
         auth = (self.sid, self.token)
-        urlprefix = "https://%s/restcomm/2012-04-24/Accounts/%s" % (host, self.sid)
+        urlprefix = protocol_host_port + "/restcomm/2012-04-24/Accounts/" + self.sid
         endpoint = '/SMS/Messages.json'
         url = urlprefix + endpoint
         method = 'GET'

--- a/test.py
+++ b/test.py
@@ -31,8 +31,28 @@ def has_not(regex, filepath):
 
 
 def main():
-    has("INFO.*org.jboss.bootstrap.microcontainer.ServerImpl.*JBoss.*Started", 'server.log')
-    has_not(".*Not all SBB are running now.*", 'server.log')
+    # =Association [name=ass1, associationType=SERVER, ipChannelType=SCTP, hostAddress=, hostPort=0, peerAddress=127.0.0.1, peerPort=8011, serverName=serv1, extraHostAddress=[]]
+    expressions = [
+        'INFO.*StackImpl.*Started.*DIAMETER.*',
+        'INFO.*ServerImpl.*Started.*Server',
+        'INFO.*ManagementImpl.*Started SCTP',
+        'INFO.*AssociationImpl.*Started Association',
+        'INFO.*M3UAManagementImpl.*Started M3UAManagement',
+        'INFO.*RouterImpl.*Started SCCP Router',
+        'INFO.*SccpResourceImpl.*Started Sccp Resource',
+        'INFO.*SmppManagement.*Started SmppManagement',
+        'INFO.*SmppShellExecutor.*Started SmppShellExecutor SmppManagement',
+        'INFO.*HttpUsersManagement.*Started of HttpUsersManagement',
+        'WARN.*SmscManagement.*Started SmscManagemet SmscManagement',
+        'INFO.*SMSCShellExecutor.*Started SMSCShellExecutor SmscManagement',
+        'INFO.*Ss7Management.*Started ...',
+        'INFO.*CounterProviderManagement-CounterHost.*Started ...',
+        'INFO.*TcapManagementJmx-TcapStack.*Started ...',
+        'INFO.*SmscStatProviderJmx-SMSC.*SmscStatProviderJmx Started ...',
+        'INFO.*org.jboss.bootstrap.microcontainer.ServerImpl.*JBoss.*Started'
+    ]
+    for expression in expressions:
+        has(expression, 'server.log')
 
 
 if __name__=='__main__':


### PR DESCRIPTION
It should get 401 (as in tadhack.restcomm.com) and not 200, but at least now we have a way to test an API call of SMSC